### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rel=noopener to external links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - [Reverse Tabnabbing]
+**Vulnerability:** External links in `index.html` used `target="_blank"` without `rel="noopener noreferrer"`.
+**Learning:** Even simple static sites can expose users to phishing attacks if external links can manipulate the opener window.
+**Prevention:** Enforce `rel="noopener noreferrer"` for all `target="_blank"` links.

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
     </p>
     <hr>
     <p>
-    Created by <a href="http://gabrielecirulli.com" target="_blank">Gabriele Cirulli.</a> Based on <a href="https://itunes.apple.com/us/app/1024!/id823499224" target="_blank">1024 by Veewo Studio</a> and conceptually similar to <a href="http://asherv.com/threes/" target="_blank">Threes by Asher Vollmer.</a>
+    Created by <a href="http://gabrielecirulli.com" target="_blank" rel="noopener noreferrer">Gabriele Cirulli.</a> Based on <a href="https://itunes.apple.com/us/app/1024!/id823499224" target="_blank" rel="noopener noreferrer">1024 by Veewo Studio</a> and conceptually similar to <a href="http://asherv.com/threes/" target="_blank" rel="noopener noreferrer">Threes by Asher Vollmer.</a>
     </p>
   </div>
 


### PR DESCRIPTION
🛡️ Sentinel Security Update

🚨 Severity: MEDIUM
💡 Vulnerability: Reverse Tabnabbing (Missing `rel="noopener noreferrer"`)
External links in `index.html` were using `target="_blank"` without `rel="noopener noreferrer"`. This allows the linked page to access the `window.opener` object, potentially enabling it to redirect the original page to a malicious site (phishing).

🎯 Impact:
If a user clicks a link to a compromised external site, that site could silently redirect the 2048 game tab to a phishing page.

🔧 Fix:
Added `rel="noopener noreferrer"` to all external links in `index.html` that use `target="_blank"`.

✅ Verification:
- Verified via `grep` that all `target="_blank"` links now have the attribute.
- Verified via Playwright script that attributes are present and page renders correctly.


---
*PR created automatically by Jules for task [7061677525382483513](https://jules.google.com/task/7061677525382483513) started by @ycechungAI*