### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix client-side DoS from unhandled JSON.parse

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application was missing a Content Security Policy (CSP), which could allow attackers to execute malicious scripts or load unauthorized resources if other vulnerabilities like XSS were present.
 **Learning:** Even simple static web applications that do not use an external backend can benefit from defense in depth by applying a strict CSP. This app does not use inline scripts or external resources, so a simple `default-src 'self'` policy is sufficient and effective.
 **Prevention:** Include a CSP meta tag in the HTML `<head>` for all static web applications.
+
+## 2026-03-23 - [Client-Side DoS via Unhandled JSON.parse]
+**Vulnerability:** The application read state from `localStorage` without validating if the contents were well-formed JSON, causing an unhandled `JSON.parse` exception if the local storage data was corrupted or tampered with.
+**Learning:** External data sources, even local ones like `localStorage`, should never be blindly trusted. If `localStorage` holds corrupted data (or is tampered with by an extension), the app crashes on load.
+**Prevention:** Always wrap `JSON.parse` operations on external data within a `try...catch` block, allowing the application to fail securely (e.g., reset the state or return null) instead of crashing entirely.

--- a/js/local_storage_manager.js
+++ b/js/local_storage_manager.js
@@ -51,7 +51,11 @@ LocalStorageManager.prototype.setBestScore = function (score) {
 // Game state getters/setters and clearing
 LocalStorageManager.prototype.getGameState = function () {
   var stateJSON = this.storage.getItem(this.gameStateKey);
-  return stateJSON ? JSON.parse(stateJSON) : null;
+  try {
+    return stateJSON ? JSON.parse(stateJSON) : null;
+  } catch (e) {
+    return null; // Fallback securely if state is corrupted
+  }
 };
 
 LocalStorageManager.prototype.setGameState = function (gameState) {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unhandled `JSON.parse` exception when reading `gameState` from `localStorage`.
🎯 Impact: If `localStorage` data is corrupted, tampered with by a third-party extension, or maliciously modified, the application crashes on load and becomes unusable (client-side DoS).
🔧 Fix: Wrapped the `JSON.parse` operation in a `try...catch` block. If an error occurs, it securely falls back to returning `null`, allowing the game to reset gracefully.
✅ Verification: Tested locally by injecting invalid JSON into `localStorage` and confirming the game successfully starts a new session instead of crashing. Also passed the JSHint linter.

---
*PR created automatically by Jules for task [4197189478066064244](https://jules.google.com/task/4197189478066064244) started by @ycechungAI*